### PR TITLE
Add binary creation through Nuitka

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,12 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
+# Nuitka
+*.build/
+*.dist/
+*.onefile-build/
+nuitka-crash-report.xml
+
 #my ones
 .minecraft/
 logs/
@@ -135,3 +141,4 @@ config.json
 .mixin.out/
 .claude/
 CLAUDE.md
+.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ build:
 		--mode=app \
 		--enable-plugin=pyqt5 \
 		--include-data-dir=pymymc/resources=resources \
+		--include-package-data=minecraft_launcher_lib \
 		--output-dir=dist \
 		pymymc
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,18 @@
 #!/usr/bin/make -f
 
+install:
+	python3 -m pip install -e .
+
 run:
 	python3 -m pymymc
+
+build:
+	python3 -m nuitka \
+		--mode=app \
+		--enable-plugin=pyqt5 \
+		--include-data-dir=pymymc/resources=resources \
+		--output-dir=dist \
+		pymymc
+
+clean:
+	rm -rf dist/*.build dist/*.dist dist/*.onefile-build

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ A lightweight Minecraft launcher built with Python and PyQt5.
 
 ## Installation
 
-Requires Python 3.7+.
+Requires Python 3.9+.
 
 ```bash
-pip install -r requirements.txt
+pip install .
 python -m pymymc
 ```
 

--- a/pymymc/constants/ui.py
+++ b/pymymc/constants/ui.py
@@ -50,6 +50,9 @@ DIALOGUE_SHADOW_BLUR = 24
 DIALOGUE_SHADOW_OFFSET = 6
 
 # Resources
-_RESOURCES_DIR = Path(__file__).resolve().parent.parent / "resources"
+_PKG_DIR = Path(__file__).resolve().parent.parent
+_RESOURCES_DIR = _PKG_DIR / "resources"
+if not _RESOURCES_DIR.is_dir():
+    _RESOURCES_DIR = _PKG_DIR.parent / "resources"
 LOGO_SMALL = str(_RESOURCES_DIR / "pymymc_logo_small.png")
 LOGO_ICON = str(_RESOURCES_DIR / "pymymc_ico.ico")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "pymymc"
+version = "0.3.0"
+description = "A lightweight Minecraft launcher GUI"
+requires-python = ">=3.9"
+dependencies = [
+    "colorama",
+    "minecraft_launcher_lib",
+    "PyQt5",
+    "requests",
+]
+
+[project.optional-dependencies]
+build = ["nuitka"]
+
+[tool.setuptools.packages.find]
+include = ["pymymc*"]
+
+[tool.setuptools.package-data]
+pymymc = ["resources/*"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-colorama
-minecraft_launcher_lib
-PyQt5
-requests


### PR DESCRIPTION
Creates binaries for the project, allowing for easy distribution.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly build/packaging changes, but it also alters runtime resource path resolution, which could break icon/logo loading in some install or bundled layouts if the directory detection is wrong.
> 
> **Overview**
> Adds `pyproject.toml` packaging metadata (including `resources/*` as package data) and removes `requirements.txt` in favor of installing via `pip install .`, while bumping the documented minimum Python to 3.9.
> 
> Introduces a Makefile workflow for editable install, running, and building a packaged binary via Nuitka (with PyQt5 plugin and bundled resources), plus `.gitignore` entries for Nuitka outputs.
> 
> Updates resource path resolution in `pymymc/constants/ui.py` to fall back to a parent `resources` directory when the in-package path is not present (to support bundled/distributed layouts).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cce338c7d8badb0ef3b857cc746722347f96da50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->